### PR TITLE
Inputs are now seperated with - instead of _

### DIFF
--- a/.github/workflows/manage-projects.yml
+++ b/.github/workflows/manage-projects.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: UCL-MIRSG/.github/actions/add-to-project@v0.16.0
         with:
-          app_id: ${{ secrets.APP_ID }}
-          app_pem: ${{ secrets.APP_PEM }}
+          app-id: ${{ secrets.APP_ID }}
+          app-pem: ${{ secrets.APP_PEM }}


### PR DESCRIPTION
Following changes in UCL-MIRSG/.github#40 inputs now need to be seperated with `-` instead of `_`