### PR TITLE
Remove references to `ansible`

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -26,5 +26,4 @@ jobs:
     steps:
       - uses: UCL-MIRSG/.github/actions/linting@6b08a270cd9c32028f964bda6b229368400e60a4 # v0.60.0
         with:
-          ansible-roles-config: ./requirements.yml
           pre-commit-config: ./.pre-commit-config.yaml

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,0 @@
----
-collections:
-  - community.general


### PR DESCRIPTION
Realistically this is not always required. I included it to make it obvious for people who didn't know, but it causes more confusion than it solves. Fixes #10.