### PR TITLE
Switch to `ubuntu-slim` for workflows

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 2
     steps:
       - name: Check links

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   linting:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: UCL-MIRSG/.github/actions/linting@a3ad20182483f30699cc84497ee7e7891df1795a # v0
         with:

--- a/.github/workflows/manage-projects.yaml
+++ b/.github/workflows/manage-projects.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   add-issue-to-project:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: UCL-MIRSG/.github/actions/add-to-project@a3ad20182483f30699cc84497ee7e7891df1795a # v0
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/UCL-MIRSG/.github
-    rev: v0.228.0
+    rev: v0.229.0
     hooks:
       - id: mirsg-hooks


### PR DESCRIPTION
This will save us money in private repos. Ideally we would do this everywhere, but at least if in the template it will affect new repos.

https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/